### PR TITLE
Fix float parsing bug in ConfigParsing

### DIFF
--- a/src/util/ConfigParsing.cpp
+++ b/src/util/ConfigParsing.cpp
@@ -137,8 +137,15 @@ void ParseDatumParamIfPossible ( std::string line, std::string identifier, datum
     line = line.substr ( 0, end_pos );
 
   std::string size = line.substr ( size_pos + ilen );
+  LOGDEBUG << "Size string: " << size;
 
-  k = std::atof ( size.c_str() );
+  std::stringstream ss;
+  ss << size;
+  datum d;
+  ss >> d;
+  
+  k = d; //std::atof ( size.c_str() );
+  LOGDEBUG << "Parsed value: " << k;
 }
 
 }

--- a/src/util/ConfigParsing.cpp
+++ b/src/util/ConfigParsing.cpp
@@ -137,7 +137,6 @@ void ParseDatumParamIfPossible ( std::string line, std::string identifier, datum
     line = line.substr ( 0, end_pos );
 
   std::string size = line.substr ( size_pos + ilen );
-  LOGDEBUG << "Size string: " << size;
 
   std::stringstream ss;
   ss << size;
@@ -145,7 +144,6 @@ void ParseDatumParamIfPossible ( std::string line, std::string identifier, datum
   ss >> d;
   
   k = d; //std::atof ( size.c_str() );
-  LOGDEBUG << "Parsed value: " << k;
 }
 
 }


### PR DESCRIPTION
*ParseDatumParamIfPossible* used std::atof for parsing resulting in truncated parameters.